### PR TITLE
Fix rounding when number is whole & ends with 0

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1,7 +1,11 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
-const rem = (px) => `${px / 16}rem`
-const round = (num) => num.toFixed(7).replace(/[.0]+$/, '')
+const round = (num) =>
+  num
+    .toFixed(7)
+    .replace(/(\.[0-9]+?)0+$/, '$1')
+    .replace(/\.0$/, '')
+const rem = (px) => `${round(px / 16)}rem`
 const em = (px, base) => `${round(px / base)}em`
 
 module.exports = {


### PR DESCRIPTION
Fixes #6

```js
round(20) // -> '20'
round(1 / 3) // -> '0.3333333'
round(2 / 3) // -> '0.6666667'
round(2 / 10) // -> '0.2'
```

Also makes use of the `round` helper in the `rem` helper