### PR TITLE
Fix link to documentation

### DIFF
--- a/demo/components/MarkdownSample.mdx
+++ b/demo/components/MarkdownSample.mdx
@@ -31,7 +31,7 @@ It adds a new `prose` class that you can slap on any block of vanilla HTML conte
 </article>
 ```
 
-For more information about how to use the plugin and the features it includes, [read the documentation](#).
+For more information about how to use the plugin and the features it includes, [read the documentation](https://github.com/tailwindcss/typography/blob/master/README.md).
 
 ---
 


### PR DESCRIPTION
The URL to the documentation at the [deployed version](https://tailwindcss-typography.netlify.app/) is missing. It exists on the master branch, but not on this branch. This PR is a shot in the dark as I don't think the `next` branch is deployed, but now you know.

![image](https://user-images.githubusercontent.com/29319414/87354937-c2dc3d80-c55f-11ea-9d40-568a3d586eda.png)
