### PR TITLE
Added a section regarding how to use the `theme()` helper function to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,29 @@ module.exports = {
 }
 ```
 
+Additionally, if you want to use the `theme()` helper function for customization, you can do so:
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    typography: (theme) => ({
+      default: {
+        css: {
+          color: theme('colors.gray.800'),
+
+          // ...
+        }
+      }
+    })
+  },
+  plugins: [
+    require('@tailwindcss/typography'),
+    // ...
+  ],
+}
+```
+
 Customizations should be applied to a specific modifier like `default` or `xl`, and must be added under the `css` property. Customizations are authored in the same [CSS-in-JS syntax](https://tailwindcss.com/docs/plugins#css-in-js-syntax) used to write Tailwind plugins.
 
 It's important to note that all customizations are **merged** with the defaults. If you'd like to completely override a provided size modifier, you can do so by disabling that modifier so the default styles are not included.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ module.exports = {
 }
 ```
 
-Additionally, if you want to use the `theme()` helper function for customization, you can do so:
+Additionally, if you want to use the `theme()` helper function to customize this plugin's styles, you can do so by bringing it into scope:
 
 ```js
 // tailwind.config.js

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ module.exports = {
 }
 ```
 
-Additionally, if you want to use the `theme()` helper function to customize this plugin's styles, you can do so by bringing it into scope:
+Like with all theme customizations in Tailwind, you can also define the `typography` key as a function if you need access to the `theme` helper:
 
 ```js
 // tailwind.config.js


### PR DESCRIPTION
I thought it would be a good idea to do this since some people (#14 ) couldn't figure out how to use the `theme()` helper function, and stuff like this should be documented anyways.